### PR TITLE
Fix/build cluster edits

### DIFF
--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -652,9 +652,11 @@ prompt_dependency_tags "$BUILD_TYPE"
 
 # reorder repos to respect dependencies
 reorder_repos_by_dependency
+echo "[DEBUG] SELECTED_REPOS after reorder_repos_by_dependency: ${SELECTED_REPOS[*]}"
 
 # validate dependencies
 validate_dependencies
+echo "[DEBUG] SELECTED_REPOS after validate_dependencies: ${SELECTED_REPOS[*]}"
 
 
 # build SIF and update symlink

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -520,8 +520,12 @@ reorder_repos_by_dependency() {
     for repo in "${priority_order[@]}"; do
         if [[ " ${remaining[*]} " =~ " ${repo} " ]]; then
             ordered+=("$repo")
-            # remove from remaining
-            remaining=("${remaining[@]/$repo}")
+            # remove from remaining (exact match only, not substring)
+            local new_remaining=()
+            for r in "${remaining[@]}"; do
+                [[ "$r" != "$repo" ]] && new_remaining+=("$r")
+            done
+            remaining=("${new_remaining[@]}")
         fi
     done
 

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -80,6 +80,9 @@ REPOS=(
 )
 REGISTRY="ghcr.io/ngwpc"
 
+# DEBUG: Show REPOS array at script start
+echo "[DEBUG] REPOS array at start: ${REPOS[*]}"
+
 BUILD_TYPE=""
 SELECTED_REPOS=()
 
@@ -371,9 +374,14 @@ set_image_source_defaults
 # expand 'all'
 if [[ " ${SELECTED_REPOS[*]} " =~ " all " ]]; then
     echo "'all' specified — building all available repos."
+    echo "[DEBUG] REPOS array before expansion: ${REPOS[*]}"
     SELECTED_REPOS=("${REPOS[@]}")
+    echo "[DEBUG] SELECTED_REPOS after 'all' expansion: ${SELECTED_REPOS[*]}"
     echo "Repos to build: ${SELECTED_REPOS[*]}"
 fi
+
+# DEBUG: Show final SELECTED_REPOS before validation
+echo "[DEBUG] SELECTED_REPOS before validation: ${SELECTED_REPOS[*]}"
 
 # validate repos
 INVALID_REPOS=()

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -354,7 +354,12 @@ fi
 
 if [[ ${#SELECTED_REPOS[@]} -eq 0 && -t 0 ]]; then
     echo "Available repos: ${REPOS[*]}"
-    read -p "Enter repos to build (space-separated from the list above): " -a SELECTED_REPOS
+    read -p "Enter repos to build (space-separated from the list above, or press Enter for all): " -a SELECTED_REPOS
+    # if user pressed Enter without typing anything, select all repos
+    if [[ ${#SELECTED_REPOS[@]} -eq 0 ]]; then
+        SELECTED_REPOS=("${REPOS[@]}")
+        echo "All repos selected: ${SELECTED_REPOS[*]}"
+    fi
 fi
 
 if [[ -z "$BUILD_TYPE" || ${#SELECTED_REPOS[@]} -eq 0 ]]; then

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -446,8 +446,8 @@ get_repo_branch() {
 prompt_dependency_tags() {
     local build_type="$1"
 
-    # only applicable to feature builds
-    [[ "$build_type" != "feature" ]] && return 0
+    # only applicable to feature and release builds
+    [[ "$build_type" != "feature" && "$build_type" != "release" ]] && return 0
     [[ ! -t 0 ]] && return 0  # not interactive
 
     # check if ngen is selected or needed
@@ -479,6 +479,22 @@ prompt_dependency_tags() {
             local tag="${ans:-$default_tag}"
             DEPENDENCY_TAGS["nwm-cal-mgr"]="$tag"
             DEPENDENCY_TAGS["nwm-fcst-mgr"]="$tag"
+        fi
+    fi
+
+    # prompt for nwm-eval-mgr branch/tag if nwm-verf is selected
+    if [[ " ${SELECTED_REPOS[@]} " =~ " nwm-verf " ]]; then
+        if [[ "$build_type" == "feature" ]]; then
+            local default_branch="feature"
+            if [[ -z "${DEPENDENCY_TAGS[nwm-verf]:-}" ]]; then
+                read -p "Which nwm-eval-mgr branch do you want nwm-verf to use? (default: ${default_branch}): " ans
+                DEPENDENCY_TAGS["nwm-verf"]="${ans:-$default_branch}"
+            fi
+        elif [[ "$build_type" == "release" ]]; then
+            if [[ -z "${DEPENDENCY_TAGS[nwm-verf]:-}" ]]; then
+                read -p "Which nwm-eval-mgr release tag do you want nwm-verf to use?: " ans
+                DEPENDENCY_TAGS["nwm-verf"]="${ans}"
+            fi
         fi
     fi
 }
@@ -551,6 +567,9 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
             ngen)
                 if [[ -z "${TAGS[ngen]:-}" ]]; then
                     read -p "Enter ngen tag: " TAGS[ngen]
+                fi
+                if [[ -z "${TAGS[ngen-forcing]:-}" ]]; then
+                    read -p "Enter ngen-forcing tag (used by ngen): " TAGS[ngen-forcing]
                 fi
             ;;
             nwm-cal-mgr)
@@ -842,8 +861,8 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
         if [[ "${IMAGE_SOURCE[ngen]}" == "build" ]]; then
             checkout_repo_tag "ngen" "${TAGS[ngen]}"
 
-            # determine ngen-forcing tag (use explicit tag if ngen-forcing is selected, otherwise use ngen's tag)
-            local forcing_tag="${TAGS[ngen-forcing]:-${TAGS[ngen]}}"
+            # use ngen-forcing tag (prompted when ngen is selected)
+            local forcing_tag="${TAGS[ngen-forcing]}"
 
             echo "[$(date '+%H:%M:%S')] Building ngen Docker image with NGEN_FORCING_TAG=${forcing_tag}"
             docker build --progress=plain --no-cache \
@@ -1210,9 +1229,13 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
                 if [[ "${IMAGE_SOURCE[nwm-verf]}" == "build" ]]; then
                     if [[ -d "${BASE_PATH}/nwm-verf" ]]; then
                         update_repo_branch "nwm-verf" "feature"
-                        echo "[$(date '+%H:%M:%S')] Building nwm-verf (feature) Docker image"
+
+                        # determine nwm-eval-mgr tag to use
+                        local nwm_eval_mgr_tag="${DEPENDENCY_TAGS[nwm-verf]:-feature}"
+
+                        echo "[$(date '+%H:%M:%S')] Building nwm-verf (feature) Docker image with NWM_EVAL_MGR_TAG=${nwm_eval_mgr_tag}"
                         docker build --progress=plain --no-cache \
-                            --build-arg NWM_EVAL_MGR_TAG="feature" \
+                            --build-arg NWM_EVAL_MGR_TAG="${nwm_eval_mgr_tag}" \
                             --tag="${REGISTRY}/nwm-verf:feature" \
                             "${BASE_PATH}/nwm-verf"
                     else

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -88,6 +88,11 @@ TARGET_REPOS_FOR_SOURCE=("ngen" "nwm-cal-mgr" "ngen-forcing" "nwm-verf" "nwm-fcs
 declare -A IMAGE_SOURCE   # map: repo -> build|pull
 IMAGE_SOURCE_DEFAULT=""
 
+# Dependency image tags for build arguments
+declare -A DEPENDENCY_TAGS  # map: dependent_repo -> dependency_tag
+# e.g., DEPENDENCY_TAGS["ngen"]="feature"  # ngen will use ngen-forcing:feature
+#       DEPENDENCY_TAGS["nwm-cal-mgr"]="v1.0"  # nwm-cal-mgr will use ngen:v1.0
+
 # map repo -> "docker_image|sif_name" (space-separated for multiples)
 images_for_repo() {
     local repo="$1"
@@ -150,6 +155,8 @@ OPTIONS:
   --source-default=MODE      Global default (build|pull) for the above repos (optional)
   --tag=REPO:TAG             For feature builds: specify tag to pull for REPO (only used when pulling).
                              Example: --tag=ngen-forcing:latest
+  --ngen-forcing-tag=TAG     For feature builds: specify ngen-forcing tag for ngen to use as build arg
+  --ngen-tag=TAG             For feature builds: specify ngen tag for nwm-cal-mgr/nwm-fcst-mgr to use
   --help, -h                 Show this help message and exit
 
 REPOS:
@@ -185,6 +192,12 @@ EXAMPLES:
 
   Feature build:
     ./build_cluster.sh --build-type=feature ngen nwm-cal-mgr
+
+  Feature build with custom dependency tags:
+    ./build_cluster.sh --build-type=feature \
+      --ngen-forcing-tag=latest --ngen-tag=development \
+      --source=ngen:build --source=nwm-cal-mgr:build \
+      ngen-forcing ngen nwm-cal-mgr
 
 NOTES:
   - If no arguments are passed, the script runs interactively
@@ -264,6 +277,21 @@ parse_args() {
                 fi
                 TAGS["$repo"]="$tag"
             ;;
+            --ngen-forcing-tag=*)
+                local tag="${1#*=}"
+                if [[ -z "$tag" ]]; then
+                    echo "Error: --ngen-forcing-tag requires a value"; exit 1
+                fi
+                DEPENDENCY_TAGS["ngen"]="$tag"
+            ;;
+            --ngen-tag=*)
+                local tag="${1#*=}"
+                if [[ -z "$tag" ]]; then
+                    echo "Error: --ngen-tag requires a value"; exit 1
+                fi
+                DEPENDENCY_TAGS["nwm-cal-mgr"]="$tag"
+                DEPENDENCY_TAGS["nwm-fcst-mgr"]="$tag"
+            ;;
             -*)
                 echo "Unknown option: $1"; exit 1
             ;;
@@ -295,6 +323,12 @@ if [[ "$BUILD_TYPE" == "development" ]]; then
         echo "Development builds always use the 'development' branch for all repos."
         exit 1
     fi
+fi
+
+# validate dependency tags are only used with feature build type
+if [[ ${#DEPENDENCY_TAGS[@]} -gt 0 && "$BUILD_TYPE" != "feature" ]]; then
+    echo "Error: --ngen-forcing-tag and --ngen-tag can only be used with --build-type=feature"
+    exit 1
 fi
 
 # --- Create directories and setup logging (after arg parsing to allow --help to work) ---
@@ -403,6 +437,104 @@ get_repo_branch() {
     fi
 }
 
+# prompt for dependency tags in interactive mode
+prompt_dependency_tags() {
+    local build_type="$1"
+
+    # only applicable to feature builds
+    [[ "$build_type" != "feature" ]] && return 0
+    [[ ! -t 0 ]] && return 0  # not interactive
+
+    # check if ngen is selected or needed
+    local ngen_selected=false
+    if [[ " ${SELECTED_REPOS[@]} " =~ " ngen " ]]; then
+        ngen_selected=true
+    fi
+
+    # check if nwm-cal-mgr or nwm-fcst-mgr is selected
+    local mgr_selected=false
+    if [[ " ${SELECTED_REPOS[@]} " =~ " nwm-cal-mgr " ]] || [[ " ${SELECTED_REPOS[@]} " =~ " nwm-fcst-mgr " ]]; then
+        mgr_selected=true
+    fi
+
+    # prompt for ngen-forcing tag if ngen is being built
+    if [[ "$ngen_selected" == "true" ]]; then
+        local default_tag="feature"
+        if [[ -z "${DEPENDENCY_TAGS[ngen]:-}" ]]; then
+            read -p "Which ngen-forcing Docker image tag do you want ngen to use? (default: ${default_tag}): " ans
+            DEPENDENCY_TAGS["ngen"]="${ans:-$default_tag}"
+        fi
+    fi
+
+    # prompt for ngen tag if nwm-cal-mgr or nwm-fcst-mgr is selected
+    if [[ "$mgr_selected" == "true" ]]; then
+        local default_tag="feature"
+        if [[ -z "${DEPENDENCY_TAGS[nwm-cal-mgr]:-}" ]]; then
+            read -p "Which ngen Docker image tag do you want nwm-cal-mgr/nwm-fcst-mgr to use? (default: ${default_tag}): " ans
+            local tag="${ans:-$default_tag}"
+            DEPENDENCY_TAGS["nwm-cal-mgr"]="$tag"
+            DEPENDENCY_TAGS["nwm-fcst-mgr"]="$tag"
+        fi
+    fi
+}
+
+# reorder SELECTED_REPOS to respect dependency chain
+# ngen-forcing must come before ngen, ngen must come before nwm-cal-mgr/nwm-fcst-mgr
+reorder_repos_by_dependency() {
+    local ordered=()
+    local remaining=("${SELECTED_REPOS[@]}")
+
+    # dependency order: ngen-forcing -> ngen -> nwm-cal-mgr/nwm-fcst-mgr -> others
+    local priority_order=("ngen-forcing" "ngen" "nwm-cal-mgr" "nwm-fcst-mgr")
+
+    # first, add priority repos in order if they exist in SELECTED_REPOS
+    for repo in "${priority_order[@]}"; do
+        if [[ " ${remaining[*]} " =~ " ${repo} " ]]; then
+            ordered+=("$repo")
+            # remove from remaining
+            remaining=("${remaining[@]/$repo}")
+        fi
+    done
+
+    # then add any remaining repos
+    for repo in "${remaining[@]}"; do
+        [[ -n "$repo" ]] && ordered+=("$repo")
+    done
+
+    SELECTED_REPOS=("${ordered[@]}")
+}
+
+# validate that dependencies are satisfied
+validate_dependencies() {
+    local errors=()
+
+    # for feature builds, check dependency chain
+    if [[ "$BUILD_TYPE" == "feature" ]]; then
+        # if ngen is being built, ensure ngen-forcing tag is available
+        if [[ " ${SELECTED_REPOS[@]} " =~ " ngen " ]] && [[ "${IMAGE_SOURCE[ngen]}" == "build" ]]; then
+            local forcing_tag="${DEPENDENCY_TAGS[ngen]:-feature}"
+            # check if ngen-forcing is being built or pulled
+            if [[ ! " ${SELECTED_REPOS[@]} " =~ " ngen-forcing " ]]; then
+                # ngen-forcing not selected, but might be available from previous build
+                echo "Warning: ngen will be built with NGEN_FORCING_TAG=${forcing_tag}, but ngen-forcing is not selected for build/pull."
+                echo "         Ensure ngen-forcing:${forcing_tag} exists or select ngen-forcing for build/pull."
+            fi
+        fi
+
+        # if nwm-cal-mgr/nwm-fcst-mgr is being built, ensure ngen tag is available
+        for repo in "nwm-cal-mgr" "nwm-fcst-mgr"; do
+            if [[ " ${SELECTED_REPOS[@]} " =~ " ${repo} " ]] && [[ "${IMAGE_SOURCE[$repo]}" == "build" ]]; then
+                local ngen_tag="${DEPENDENCY_TAGS[$repo]:-feature}"
+                # check if ngen is being built or pulled
+                if [[ ! " ${SELECTED_REPOS[@]} " =~ " ngen " ]]; then
+                    echo "Warning: ${repo} will be built with NGEN_IMAGE_TAG=${ngen_tag}, but ngen is not selected for build/pull."
+                    echo "         Ensure ngen:${ngen_tag} exists or select ngen for build/pull."
+                fi
+            fi
+        done
+    fi
+}
+
 # --- tag prompts for release and feature (when pulling) ---
 declare -A TAGS
 if [[ "$BUILD_TYPE" == "release" ]]; then
@@ -482,6 +614,15 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
         fi
     done
 fi
+
+# prompt for dependency tags
+prompt_dependency_tags "$BUILD_TYPE"
+
+# reorder repos to respect dependencies
+reorder_repos_by_dependency
+
+# validate dependencies
+validate_dependencies
 
 
 # build SIF and update symlink
@@ -651,6 +792,43 @@ checkout_repo_tag() {
 if [[ "$BUILD_TYPE" == "release" ]]; then
     cd "$BASE_PATH"
 
+    # handle ngen-forcing first if selected (dependency of ngen)
+    if [[ " ${SELECTED_REPOS[@]} " =~ " ngen-forcing " ]]; then
+        if [[ -z "${TAGS[ngen-forcing]:-}" ]]; then
+            echo "Error: ngen-forcing is selected but no tag was provided."; exit 1
+        fi
+
+        if [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
+            if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
+                checkout_repo_tag "ngen-forcing" "${TAGS[ngen-forcing]}"
+                echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
+                    --tag="${REGISTRY}/ngen-bmi-forcing:${TAGS[ngen-forcing]}" \
+                    "${BASE_PATH}/ngen-forcing"
+
+                echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
+                    --tag="${REGISTRY}/ngen-lumped-forcing:${TAGS[ngen-forcing]}" \
+                    "${BASE_PATH}/ngen-forcing"
+
+                echo "[$(date '+%H:%M:%S')] Building ngen-coastal Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
+                    --tag="${REGISTRY}/ngen-coastal:${TAGS[ngen-forcing]}" \
+                    "${BASE_PATH}/ngen-forcing"
+            else
+                echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
+            fi
+        else
+            echo "[$(date '+%H:%M:%S')] Pulling ngen-forcing Docker images"
+            docker pull "${REGISTRY}/ngen-bmi-forcing:${TAGS[ngen-forcing]}"
+            docker pull "${REGISTRY}/ngen-lumped-forcing:${TAGS[ngen-forcing]}"
+            docker pull "${REGISTRY}/ngen-coastal:${TAGS[ngen-forcing]}"
+        fi
+    fi
+
     # ngen first (build/pull even if not explicitly selected, if needed by other repos)
     if [[ " ${SELECTED_REPOS[@]} " =~ " ngen " ]] || [[ -n "${TAGS[ngen]:-}" ]]; then
         if [[ -z "${TAGS[ngen]:-}" ]]; then
@@ -658,8 +836,13 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
         fi
         if [[ "${IMAGE_SOURCE[ngen]}" == "build" ]]; then
             checkout_repo_tag "ngen" "${TAGS[ngen]}"
-            echo "[$(date '+%H:%M:%S')] Building ngen Docker image"
+
+            # determine ngen-forcing tag (use explicit tag if ngen-forcing is selected, otherwise use ngen's tag)
+            local forcing_tag="${TAGS[ngen-forcing]:-${TAGS[ngen]}}"
+
+            echo "[$(date '+%H:%M:%S')] Building ngen Docker image with NGEN_FORCING_TAG=${forcing_tag}"
             docker build --progress=plain --no-cache \
+                --build-arg NGEN_FORCING_TAG="${forcing_tag}" \
                 --tag="${REGISTRY}/ngen:${TAGS[ngen]}" \
                 "${BASE_PATH}/ngen"
         else
@@ -684,39 +867,7 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
                 fi
             ;;
             "ngen-forcing")
-                if [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
-                    if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
-                        checkout_repo_tag "ngen-forcing" "${TAGS[ngen-forcing]}" || true
-                        echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
-                            --tag="${REGISTRY}/ngen-bmi-forcing:${TAGS[ngen-forcing]}" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                        echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
-                            --tag="${REGISTRY}/ngen-lumped-forcing:${TAGS[ngen-forcing]}" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                        echo "[$(date '+%H:%M:%S')] Building ngen-coastal Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
-                            --tag="${REGISTRY}/ngen-coastal:${TAGS[ngen-forcing]}" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                    else
-                        echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
-                    fi
-                else
-
-                    echo "[$(date '+%H:%M:%S')] Pulling ngen-bmi-forcing Docker image"
-                    docker pull "${REGISTRY}/ngen-bmi-forcing:${TAGS[ngen-forcing]}"
-                    echo "[$(date '+%H:%M:%S')] Pulling ngen-lumped-forcing Docker image"
-                    docker pull "${REGISTRY}/ngen-lumped-forcing:${TAGS[ngen-forcing]}"
-                    echo "[$(date '+%H:%M:%S')] Pulling ngen-coastal Docker image"
-                    docker pull "${REGISTRY}/ngen-coastal:${TAGS[ngen-forcing]}"
-                fi
+                : # handled above before ngen
             ;;
             "nwm-fcst-mgr")
                 if [[ "${IMAGE_SOURCE[nwm-fcst-mgr]}" == "pull" ]]; then
@@ -779,13 +930,40 @@ if [[ "$BUILD_TYPE" == "development" ]]; then
         echo "Note: ngen is required as a dependency for nwm-cal-mgr/nwm-fcst-mgr"
     fi
 
+    # handle ngen-forcing first if it's selected and building
+    if [[ " ${SELECTED_REPOS[@]} " =~ " ngen-forcing " ]] && [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
+        if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
+            update_repo_branch "ngen-forcing" "development"
+            echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing (development) Docker image"
+            docker build --progress=plain --no-cache \
+                --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
+                --tag="${REGISTRY}/ngen-bmi-forcing:latest" \
+                "${BASE_PATH}/ngen-forcing"
+
+            echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing (development) Docker image"
+            docker build --progress=plain --no-cache \
+                --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
+                --tag="${REGISTRY}/ngen-lumped-forcing:latest" \
+                "${BASE_PATH}/ngen-forcing"
+
+            echo "[$(date '+%H:%M:%S')] Building ngen-coastal (development) Docker image"
+            docker build --progress=plain --no-cache \
+                --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
+                --tag="${REGISTRY}/ngen-coastal:latest" \
+                "${BASE_PATH}/ngen-forcing"
+        else
+            echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
+        fi
+    fi
+
     # build or pull ngen first so downstream builds may use ngen:latest
     if [[ "$NGEN_NEEDED" == "true" ]]; then
         if [[ "${IMAGE_SOURCE[ngen]}" == "build" ]]; then
             if [[ -d "${BASE_PATH}/ngen" ]]; then
                 update_repo_branch "ngen" "development"
-                echo "[$(date '+%H:%M:%S')] Building ngen (development) Docker image"
+                echo "[$(date '+%H:%M:%S')] Building ngen (development) Docker image with NGEN_FORCING_TAG=latest"
                 docker build --progress=plain --no-cache \
+                    --build-arg NGEN_FORCING_TAG="latest" \
                     --tag="${REGISTRY}/ngen:latest" \
                     "${BASE_PATH}/ngen"
             else
@@ -850,28 +1028,9 @@ if [[ "$BUILD_TYPE" == "development" ]]; then
                 fi
             ;;
             "ngen-forcing")
+                # already handled before ngen if building
                 if [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
-                    if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
-                        update_repo_branch "ngen-forcing" "development"
-                        echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing (development) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
-                            --tag="${REGISTRY}/ngen-bmi-forcing:latest" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                        echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing (development) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
-                            --tag="${REGISTRY}/ngen-lumped-forcing:latest" \
-                            "${BASE_PATH}/ngen-forcing"
-                        echo "[$(date '+%H:%M:%S')] Building ngen-coastal (development) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
-                            --tag="${REGISTRY}/ngen-coastal:latest" \
-                            "${BASE_PATH}/ngen-forcing"
-                    else
-                        echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
-                    fi
+                    : # skip, already built above
                 fi
             ;;
             "ngen")
@@ -908,6 +1067,15 @@ fi
 if [[ "$BUILD_TYPE" == "feature" ]]; then
     cd "$BASE_PATH"
 
+    # check if ngen-forcing is needed as a dependency for ngen
+    NGEN_FORCING_NEEDED=false
+    if [[ " ${SELECTED_REPOS[@]} " =~ " ngen-forcing " ]]; then
+        NGEN_FORCING_NEEDED=true
+    elif [[ " ${SELECTED_REPOS[@]} " =~ " ngen " ]]; then
+        NGEN_FORCING_NEEDED=true
+        echo "Note: ngen-forcing is required as a dependency for ngen (if building ngen from source)"
+    fi
+
     # check if ngen is needed as a dependency for other repos
     NGEN_NEEDED=false
     if [[ " ${SELECTED_REPOS[@]} " =~ " ngen " ]]; then
@@ -917,13 +1085,60 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
         echo "Note: ngen is required as a dependency for nwm-cal-mgr/nwm-fcst-mgr"
     fi
 
+    # handle ngen-forcing first (dependency of ngen)
+    if [[ "$NGEN_FORCING_NEEDED" == "true" ]]; then
+        if [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
+            if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
+                update_repo_branch "ngen-forcing" "feature"
+                echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing (feature) Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
+                    --tag="${REGISTRY}/ngen-bmi-forcing:feature" \
+                    "${BASE_PATH}/ngen-forcing"
+
+                echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing (feature) Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
+                    --tag="${REGISTRY}/ngen-lumped-forcing:feature" \
+                    "${BASE_PATH}/ngen-forcing"
+
+                echo "[$(date '+%H:%M:%S')] Building ngen-coastal (feature) Docker image"
+                docker build --progress=plain --no-cache \
+                    --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
+                    --tag="${REGISTRY}/ngen-coastal:feature" \
+                    "${BASE_PATH}/ngen-forcing"
+            else
+                echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
+            fi
+        else
+            # pulling ngen-forcing
+            forcing_tag="${TAGS[ngen-forcing]:-feature}"
+            echo "[$(date '+%H:%M:%S')] Pulling ngen-forcing Docker images with tag: ${forcing_tag}"
+            docker pull "${REGISTRY}/ngen-bmi-forcing:${forcing_tag}"
+            docker pull "${REGISTRY}/ngen-lumped-forcing:${forcing_tag}"
+            docker pull "${REGISTRY}/ngen-coastal:${forcing_tag}"
+
+            # retag as :feature for consistency
+            if [[ "$forcing_tag" != "feature" ]]; then
+                docker tag "${REGISTRY}/ngen-bmi-forcing:${forcing_tag}" "${REGISTRY}/ngen-bmi-forcing:feature"
+                docker tag "${REGISTRY}/ngen-lumped-forcing:${forcing_tag}" "${REGISTRY}/ngen-lumped-forcing:feature"
+                docker tag "${REGISTRY}/ngen-coastal:${forcing_tag}" "${REGISTRY}/ngen-coastal:feature"
+            fi
+        fi
+    fi
+
     # build or pull ngen first so downstream builds may use ngen:feature
     if [[ "$NGEN_NEEDED" == "true" ]]; then
         if [[ "${IMAGE_SOURCE[ngen]}" == "build" ]]; then
             if [[ -d "${BASE_PATH}/ngen" ]]; then
                 update_repo_branch "ngen" "feature"
-                echo "[$(date '+%H:%M:%S')] Building ngen (feature) Docker image"
+
+                # determine ngen-forcing tag to use
+                local ngen_forcing_tag="${DEPENDENCY_TAGS[ngen]:-feature}"
+
+                echo "[$(date '+%H:%M:%S')] Building ngen (feature) Docker image with NGEN_FORCING_TAG=${ngen_forcing_tag}"
                 docker build --progress=plain --no-cache \
+                    --build-arg NGEN_FORCING_TAG="${ngen_forcing_tag}" \
                     --tag="${REGISTRY}/ngen:feature" \
                     "${BASE_PATH}/ngen"
             else
@@ -934,7 +1149,9 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
             echo "[$(date '+%H:%M:%S')] Pulling ngen Docker image with tag: ${ngen_tag}"
             docker pull "${REGISTRY}/ngen:${ngen_tag}"
             # retag as :feature for consistency with build workflow
-            docker tag "${REGISTRY}/ngen:${ngen_tag}" "${REGISTRY}/ngen:feature"
+            if [[ "$ngen_tag" != "feature" ]]; then
+                docker tag "${REGISTRY}/ngen:${ngen_tag}" "${REGISTRY}/ngen:feature"
+            fi
         fi
     fi
 
@@ -952,9 +1169,13 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
                 if [[ "${IMAGE_SOURCE[nwm-cal-mgr]}" == "build" ]]; then
                     if [[ -d "${BASE_PATH}/nwm-cal-mgr" ]]; then
                         update_repo_branch "nwm-cal-mgr" "feature"
-                        echo "[$(date '+%H:%M:%S')] Building nwm-cal-mgr (feature) Docker image"
+
+                        # determine ngen tag to use
+                        local ngen_tag="${DEPENDENCY_TAGS[nwm-cal-mgr]:-feature}"
+
+                        echo "[$(date '+%H:%M:%S')] Building nwm-cal-mgr (feature) Docker image with NGEN_IMAGE_TAG=${ngen_tag}"
                         docker build --progress=plain --no-cache \
-                            --build-arg NGEN_IMAGE_TAG="feature" \
+                            --build-arg NGEN_IMAGE_TAG="${ngen_tag}" \
                             --tag="${REGISTRY}/nwm-cal-mgr:feature" \
                             "${BASE_PATH}/nwm-cal-mgr"
                     else
@@ -966,9 +1187,13 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
                 if [[ "${IMAGE_SOURCE[nwm-fcst-mgr]}" == "build" ]]; then
                     if [[ -d "${BASE_PATH}/nwm-fcst-mgr" ]]; then
                         update_repo_branch "nwm-fcst-mgr" "feature"
-                        echo "[$(date '+%H:%M:%S')] Building nwm-fcst-mgr (feature) Docker image"
+
+                        # determine ngen tag to use
+                        local ngen_tag="${DEPENDENCY_TAGS[nwm-fcst-mgr]:-feature}"
+
+                        echo "[$(date '+%H:%M:%S')] Building nwm-fcst-mgr (feature) Docker image with NGEN_IMAGE_TAG=${ngen_tag}"
                         docker build --progress=plain --no-cache \
-                            --build-arg NGEN_IMAGE_TAG="feature" \
+                            --build-arg NGEN_IMAGE_TAG="${ngen_tag}" \
                             --tag="${REGISTRY}/nwm-fcst-mgr:feature" \
                             "${BASE_PATH}/nwm-fcst-mgr"
                     else
@@ -991,30 +1216,7 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
                 fi
             ;;
             "ngen-forcing")
-                if [[ "${IMAGE_SOURCE[ngen-forcing]}" == "build" ]]; then
-                    if [[ -d "${BASE_PATH}/ngen-forcing" ]]; then
-                        update_repo_branch "ngen-forcing" "feature"
-                        echo "[$(date '+%H:%M:%S')] Building ngen-bmi-forcing (feature) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.bmi-forcings" \
-                            --tag="${REGISTRY}/ngen-bmi-forcing:feature" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                        echo "[$(date '+%H:%M:%S')] Building ngen-lumped-forcing (feature) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.lumped-forcings" \
-                            --tag="${REGISTRY}/ngen-lumped-forcing:feature" \
-                            "${BASE_PATH}/ngen-forcing"
-
-                        echo "[$(date '+%H:%M:%S')] Building ngen-coastal (feature) Docker image"
-                        docker build --progress=plain --no-cache \
-                            --file "${BASE_PATH}/ngen-forcing/Dockerfile.ngencoastal" \
-                            --tag="${REGISTRY}/ngen-coastal:feature" \
-                            "${BASE_PATH}/ngen-forcing"
-                    else
-                        echo "Error: ${BASE_PATH}/ngen-forcing not found; cannot build."; exit 1
-                    fi
-                fi
+                : # handled above before ngen
             ;;
             "ngen")
                 : # handled above if building

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -1062,14 +1062,19 @@ if [[ "$BUILD_TYPE" == "development" ]]; then
             ;;
         esac
 
+        # DEBUG: Show which repo is being processed
+        echo "[DEBUG] Processing repo: '$repo' from SELECTED_REPOS: ${SELECTED_REPOS[*]}"
+
         # for each repo that produces a SIF, use the locally built image if mode==build,
         # otherwise pull the image
         if repo_has_sif "$repo"; then
+            echo "[DEBUG] Repo '$repo' produces SIF, images: $(images_for_repo "$repo")"
             for pair in $(images_for_repo "$repo"); do
                 [[ -z "$pair" ]] && continue
                 docker_img="${pair%%|*}"
                 sif_name="${pair##*|}"
                 IMAGE="${REGISTRY}/${docker_img}:latest"
+                echo "[DEBUG] Extracted docker_img='$docker_img', sif_name='$sif_name', IMAGE='$IMAGE'"
 
                 if [[ "${IMAGE_SOURCE[$repo]}" != "build" ]]; then
                     echo "[$(date '+%H:%M:%S')] Pulling docker image for SIF: $IMAGE"
@@ -1251,18 +1256,24 @@ if [[ "$BUILD_TYPE" == "feature" ]]; then
             ;;
         esac
 
+        # DEBUG: Show which repo is being processed
+        echo "[DEBUG] Processing repo: '$repo' from SELECTED_REPOS: ${SELECTED_REPOS[*]}"
+
         # for each repo that produces a SIF, use the locally built image if mode==build,
         # otherwise pull the specified tag and retag as :feature
         if repo_has_sif "$repo"; then
+            echo "[DEBUG] Repo '$repo' produces SIF, images: $(images_for_repo "$repo")"
             for pair in $(images_for_repo "$repo"); do
                 [[ -z "$pair" ]] && continue
                 docker_img="${pair%%|*}"
                 sif_name="${pair##*|}"
+                echo "[DEBUG] Extracted docker_img='$docker_img', sif_name='$sif_name'"
 
                 if [[ "${IMAGE_SOURCE[$repo]}" != "build" ]]; then
                     # use tag from TAGS array if pulling, otherwise default to :feature
                     pull_tag="${TAGS[$repo]:-feature}"
                     pull_image="${REGISTRY}/${docker_img}:${pull_tag}"
+                    echo "[DEBUG] pull_image='$pull_image'"
                     echo "[$(date '+%H:%M:%S')] Pulling docker image for SIF: $pull_image"
                     docker pull "$pull_image"
 

--- a/parallel_works_scripts/startup_cluster.sh
+++ b/parallel_works_scripts/startup_cluster.sh
@@ -88,9 +88,21 @@ else
     echo "warn: $SRC_NGEN_SCRIPT not found or unreadable; skipping /usr/local/bin/ngen installation" >&2
 fi
 
-# add ngencerf-server logrotate job to root's crontab
-CRON_ENTRY='0 10,22 * * * [ -f /ngencerf-app/ngencerf-server/logrotate-ngencerf.prod.conf ] && /usr/sbin/logrotate -f /ngencerf-app/ngencerf-server/logrotate-ngencerf.prod.conf'
+# add ngencerf-server logrotate job to /etc/cron.d
+# note: added root before the command, which is required for /etc/cron.d files
+LOGROTATE_CONF="/ngencerf-app/ngencerf-server/logrotate-ngencerf.prod.conf"
+CRON_FILE='/etc/cron.d/ngencerf-logrotate'
+CRON_JOB="0 10,22 * * * root [ -f $LOGROTATE_CONF ] && /usr/sbin/logrotate -f $LOGROTATE_CONF"
 
-( sudo crontab -l 2>/dev/null; echo "$CRON_ENTRY" ) | sudo crontab -
+echo "$CRON_JOB" | sudo tee "$CRON_FILE" > /dev/null
+sudo chmod 0644 "$CRON_FILE"
+
+# set permissions on the logrotate config if it exists
+if [ -f "$LOGROTATE_CONF" ]; then
+    sudo chown root:root "$LOGROTATE_CONF"
+    sudo chmod 0644 "$LOGROTATE_CONF"
+else
+    echo "warn: $LOGROTATE_CONF not found; skipping permission fix."
+fi
 
 echo "cluster startup complete"


### PR DESCRIPTION
Improve dependency management in build_cluster.sh
- Release builds: Now prompt for ngen-forcing tag when ngen is selected
- Feature/Release builds: Added prompts for nwm-eval-mgr when nwm-verf is selected
- Feature builds: nwm-verf now uses DEPENDENCY_TAG variable instead of hardcoded 'feature'
- Release builds: ngen uses explicit ngen-forcing tag without fallback

These changes ensure users can specify correct dependency versions for all build types while maintaining proper build order: ngen-forcing → ngen → nwm-cal-mgr/nwm-fcst-mgr