### PR TITLE
Add file and directory cleanup subcommands with interactive confirmation

### DIFF
--- a/parallel_works_scripts/cleanup_cluster.sh
+++ b/parallel_works_scripts/cleanup_cluster.sh
@@ -22,6 +22,7 @@
 #   "nginx-unprivileged.sif" is always excluded regardless of --exclude.
 #   --exclude accepts a comma-separated list of filenames (no paths).
 #   --dry-run prints what would be deleted without removing anything.
+#   Without --dry-run, shows the file list and asks for confirmation before deleting.
 #
 #   Example:
 #     cleanup_cluster.sh --files \
@@ -35,6 +36,7 @@
 #   NEVER deletes directories that are currently active PW job sessions.
 #   --targets accepts a comma-separated list of directory names (not full paths).
 #   --dry-run prints what would be deleted without removing anything.
+#   Without --dry-run, shows the directory list and asks for confirmation before deleting.
 #
 #   Example:
 #     cleanup_cluster.sh --dirs \
@@ -145,39 +147,57 @@ cmd_files() {
     echo "  Path    : $path"
     echo "  Cutoff  : files older than $cutoff will be deleted"
     echo "  Excluded: ${!exclude_set[*]}"
-    echo "  Dry run : $dry_run"
+    if $dry_run; then
+        echo "  Mode    : DRY RUN — nothing will be deleted"
+    else
+        echo "  Mode    : LIVE — will prompt for confirmation before deleting"
+    fi
     echo ""
 
-    # Find files strictly older than cutoff (not modified on or after cutoff)
-    local found=0
+    # Collect eligible files (separated from skipped ones)
+    local -a to_delete=()
     while IFS= read -r -d '' file; do
         local name
         name="$(basename "$file")"
-
         if [[ -n "${exclude_set[$name]:-}" ]]; then
             echo "  [SKIP]   $file  (excluded)"
-            continue
-        fi
-
-        found=1
-        if $dry_run; then
-            echo "  [DRY-RUN] would delete: $file"
         else
-            echo "  [DELETE]  $file"
-            rm -f "$file"
+            to_delete+=("$file")
         fi
     done < <(find "$path" -maxdepth 1 -type f ! -newermt "$cutoff" -print0)
 
-    if [[ $found -eq 0 ]]; then
+    if [[ ${#to_delete[@]} -eq 0 ]]; then
         echo "  No eligible files found."
+        echo ""
+        echo "Nothing to delete."
+        return 0
     fi
 
     echo ""
+    echo "  Files to be deleted (${#to_delete[@]}):"
+    for file in "${to_delete[@]}"; do
+        echo "    $file"
+    done
+    echo ""
+
     if $dry_run; then
         echo "Dry run complete. No files were deleted."
-    else
-        echo "File cleanup complete."
+        return 0
     fi
+
+    read -r -p "Proceed with deleting the ${#to_delete[@]} file(s) listed above? [y/N] " confirm
+    if [[ "${confirm,,}" != "y" ]]; then
+        echo "Aborted. No files were deleted."
+        return 0
+    fi
+
+    echo ""
+    for file in "${to_delete[@]}"; do
+        echo "  [DELETE]  $file"
+        rm -f "$file"
+    done
+    echo ""
+    echo "File cleanup complete."
 }
 
 # ---------------------------------------------------------------------------
@@ -212,13 +232,18 @@ cmd_dirs() {
     echo "=== Directory cleanup ==="
     echo "  Path     : $path"
     echo "  Targets  : ${targets[*]}"
-    echo "  Dry run  : $dry_run"
+    if $dry_run; then
+        echo "  Mode     : DRY RUN — nothing will be deleted"
+    else
+        echo "  Mode     : LIVE — will prompt for confirmation before deleting"
+    fi
     echo ""
-    echo "  IMPORTANT: Only directories verified as inactive should be deleted."
-    echo "  Check the PW Sessions tab before proceeding."
+    echo "  !! IMPORTANT: Only delete directories you have verified are NOT active"
+    echo "  !! in the PW Sessions tab. Active job directories must not be removed."
     echo ""
 
-    local found=0
+    # Collect directories that actually exist
+    local -a to_delete=()
     for target in "${targets[@]}"; do
         target="${target// /}"   # strip accidental spaces
         [[ -z "$target" ]] && continue
@@ -227,28 +252,44 @@ cmd_dirs() {
 
         if [[ ! -d "$full_path" ]]; then
             echo "  [SKIP]   $full_path  (not found)"
-            continue
-        fi
-
-        found=1
-        if $dry_run; then
-            echo "  [DRY-RUN] would delete: $full_path"
         else
-            echo "  [DELETE]  $full_path"
-            rm -rf "$full_path"
+            to_delete+=("$full_path")
         fi
     done
 
-    if [[ $found -eq 0 ]]; then
+    if [[ ${#to_delete[@]} -eq 0 ]]; then
         echo "  No target directories found."
+        echo ""
+        echo "Nothing to delete."
+        return 0
     fi
 
     echo ""
+    echo "  Directories to be deleted (${#to_delete[@]}):"
+    for dir in "${to_delete[@]}"; do
+        echo "    $dir"
+    done
+    echo ""
+
     if $dry_run; then
         echo "Dry run complete. No directories were deleted."
-    else
-        echo "Directory cleanup complete."
+        return 0
     fi
+
+    echo "  Have you confirmed these directories are NOT active in the PW Sessions tab?"
+    read -r -p "  Proceed with deleting the ${#to_delete[@]} director(y/ies) listed above? [y/N] " confirm
+    if [[ "${confirm,,}" != "y" ]]; then
+        echo "Aborted. No directories were deleted."
+        return 0
+    fi
+
+    echo ""
+    for dir in "${to_delete[@]}"; do
+        echo "  [DELETE]  $dir"
+        rm -rf "$dir"
+    done
+    echo ""
+    echo "Directory cleanup complete."
 }
 
 # ---------------------------------------------------------------------------

--- a/parallel_works_scripts/cleanup_cluster.sh
+++ b/parallel_works_scripts/cleanup_cluster.sh
@@ -1,6 +1,56 @@
 #!/bin/bash
 
-# delete_docker_image: deletes a specific image and related containers, then prunes
+# ==============================================================================
+# cleanup_cluster.sh
+# ==============================================================================
+#
+# IMPORTANT: Run this script ONLY from the PW login node (the machine you land
+# on when opening a fresh terminal on Parallel Works). NEVER run it from inside
+# a cluster node.
+#
+# SUBCOMMANDS
+# -----------
+#
+# --docker <repo:tag>
+#   Delete a specific Docker image and its containers, then prune.
+#
+# --docker all
+#   Delete all Docker images and associated data.
+#
+# --files --path <dir> --cutoff <YYYY-MM-DD> [--exclude <name,...>] [--dry-run]
+#   Delete files in <dir> that are OLDER than <cutoff>.
+#   "nginx-unprivileged.sif" is always excluded regardless of --exclude.
+#   --exclude accepts a comma-separated list of filenames (no paths).
+#   --dry-run prints what would be deleted without removing anything.
+#
+#   Example:
+#     cleanup_cluster.sh --files \
+#       --path /ngencerf-app/singularity \
+#       --cutoff 2026-02-04 \
+#       --exclude "nginx-unprivileged.sif" \
+#       --dry-run
+#
+# --dirs --path <dir> --targets <name,...> [--dry-run]
+#   Delete specific subdirectories inside <dir>.
+#   NEVER deletes directories that are currently active PW job sessions.
+#   --targets accepts a comma-separated list of directory names (not full paths).
+#   --dry-run prints what would be deleted without removing anything.
+#
+#   Example:
+#     cleanup_cluster.sh --dirs \
+#       --path /home/ngen-pw-user/pw/jobs/ngencerf \
+#       --targets "00100,00101" \
+#       --dry-run
+#
+# ==============================================================================
+
+# Filename that must never be deleted under any circumstances
+readonly ALWAYS_EXCLUDE="nginx-unprivileged.sif"
+
+# ---------------------------------------------------------------------------
+# Docker helpers
+# ---------------------------------------------------------------------------
+
 delete_docker_image() {
     local repo="$1"
     local tag="$2"
@@ -13,7 +63,6 @@ delete_docker_image() {
 
     echo "Looking for containers using image: $image"
 
-    # find and remove all containers using the image
     local containers
     containers=$(docker ps -a --filter ancestor="$image" -q)
 
@@ -25,18 +74,15 @@ delete_docker_image() {
         echo "No containers found using image"
     fi
 
-    # remove the image
     echo "Deleting image: $image"
     docker rmi "$image"
 
-    # prune unused data
     echo "Cleaning up dangling images, volumes, and networks..."
     docker system prune -f --volumes
 
     echo "Done."
 }
 
-# delete_all_docker_data: removes all images and performs full cleanup
 delete_all_docker_data() {
     echo "Stopping and removing all containers..."
     docker rm -f $(docker ps -aq) 2>/dev/null
@@ -50,35 +96,227 @@ delete_all_docker_data() {
     echo "Done."
 }
 
-# main CLI handler
-main() {
+# ---------------------------------------------------------------------------
+# --files subcommand
+# ---------------------------------------------------------------------------
+
+cmd_files() {
+    local path="" cutoff="" exclude_arg="" dry_run=false
+
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --path)    path="$2";    shift 2 ;;
+            --cutoff)  cutoff="$2";  shift 2 ;;
+            --exclude) exclude_arg="$2"; shift 2 ;;
+            --dry-run) dry_run=true; shift ;;
+            *) echo "Unknown --files option: $1"; exit 1 ;;
+        esac
+    done
+
+    if [[ -z "$path" || -z "$cutoff" ]]; then
+        echo "Error: --files requires --path and --cutoff"
+        echo "Usage: cleanup_cluster.sh --files --path <dir> --cutoff <YYYY-MM-DD> [--exclude <name,...>] [--dry-run]"
+        exit 1
+    fi
+
+    if [[ ! -d "$path" ]]; then
+        echo "Error: path does not exist: $path"
+        exit 1
+    fi
+
+    # Validate cutoff format
+    if ! date -d "$cutoff" &>/dev/null; then
+        echo "Error: invalid cutoff date '$cutoff'. Use YYYY-MM-DD format."
+        exit 1
+    fi
+
+    # Build exclusion set (always include the hard-coded guard)
+    declare -A exclude_set
+    exclude_set["$ALWAYS_EXCLUDE"]=1
+    if [[ -n "$exclude_arg" ]]; then
+        IFS=',' read -ra parts <<< "$exclude_arg"
+        for part in "${parts[@]}"; do
+            part="${part// /}"   # strip any accidental spaces
+            [[ -n "$part" ]] && exclude_set["$part"]=1
+        done
+    fi
+
+    echo "=== File cleanup ==="
+    echo "  Path    : $path"
+    echo "  Cutoff  : files older than $cutoff will be deleted"
+    echo "  Excluded: ${!exclude_set[*]}"
+    echo "  Dry run : $dry_run"
+    echo ""
+
+    # Find files strictly older than cutoff (not modified on or after cutoff)
+    local found=0
+    while IFS= read -r -d '' file; do
+        local name
+        name="$(basename "$file")"
+
+        if [[ -n "${exclude_set[$name]:-}" ]]; then
+            echo "  [SKIP]   $file  (excluded)"
+            continue
+        fi
+
+        found=1
+        if $dry_run; then
+            echo "  [DRY-RUN] would delete: $file"
+        else
+            echo "  [DELETE]  $file"
+            rm -f "$file"
+        fi
+    done < <(find "$path" -maxdepth 1 -type f ! -newermt "$cutoff" -print0)
+
+    if [[ $found -eq 0 ]]; then
+        echo "  No eligible files found."
+    fi
+
+    echo ""
+    if $dry_run; then
+        echo "Dry run complete. No files were deleted."
+    else
+        echo "File cleanup complete."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# --dirs subcommand
+# ---------------------------------------------------------------------------
+
+cmd_dirs() {
+    local path="" targets_arg="" dry_run=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --path)    path="$2";    shift 2 ;;
+            --targets) targets_arg="$2"; shift 2 ;;
+            --dry-run) dry_run=true; shift ;;
+            *) echo "Unknown --dirs option: $1"; exit 1 ;;
+        esac
+    done
+
+    if [[ -z "$path" || -z "$targets_arg" ]]; then
+        echo "Error: --dirs requires --path and --targets"
+        echo "Usage: cleanup_cluster.sh --dirs --path <dir> --targets <name,...> [--dry-run]"
+        exit 1
+    fi
+
+    if [[ ! -d "$path" ]]; then
+        echo "Error: path does not exist: $path"
+        exit 1
+    fi
+
+    IFS=',' read -ra targets <<< "$targets_arg"
+
+    echo "=== Directory cleanup ==="
+    echo "  Path     : $path"
+    echo "  Targets  : ${targets[*]}"
+    echo "  Dry run  : $dry_run"
+    echo ""
+    echo "  IMPORTANT: Only directories verified as inactive should be deleted."
+    echo "  Check the PW Sessions tab before proceeding."
+    echo ""
+
+    local found=0
+    for target in "${targets[@]}"; do
+        target="${target// /}"   # strip accidental spaces
+        [[ -z "$target" ]] && continue
+
+        local full_path="${path}/${target}"
+
+        if [[ ! -d "$full_path" ]]; then
+            echo "  [SKIP]   $full_path  (not found)"
+            continue
+        fi
+
+        found=1
+        if $dry_run; then
+            echo "  [DRY-RUN] would delete: $full_path"
+        else
+            echo "  [DELETE]  $full_path"
+            rm -rf "$full_path"
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo "  No target directories found."
+    fi
+
+    echo ""
+    if $dry_run; then
+        echo "Dry run complete. No directories were deleted."
+    else
+        echo "Directory cleanup complete."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage:
+  cleanup_cluster.sh --docker <repo:tag>        Delete a specific Docker image
+  cleanup_cluster.sh --docker all               Delete all Docker images and data
+
+  cleanup_cluster.sh --files \\
+    --path <dir> \\
+    --cutoff <YYYY-MM-DD> \\
+    [--exclude <name,...>] \\
+    [--dry-run]
+
+  cleanup_cluster.sh --dirs \\
+    --path <dir> \\
+    --targets <name,...> \\
+    [--dry-run]
+
+NOTE: Run only from the PW login node, never from inside a cluster.
+EOF
+}
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        usage
+        exit 0
+    fi
+
+    case "$1" in
         --docker)
             shift
-            docker_arg="$1"
+            local docker_arg="$1"
+            shift
             if [[ "$docker_arg" == "all" ]]; then
                 delete_all_docker_data
             else
-                repo="${docker_arg%%:*}"
-                tag="${docker_arg##*:}"
+                local repo="${docker_arg%%:*}"
+                local tag="${docker_arg##*:}"
                 if [[ "$repo" == "$tag" ]]; then
-                    echo "Invalid image format. Use repo:tag"
+                    echo "Error: invalid image format. Use repo:tag"
                     exit 1
                 fi
                 delete_docker_image "$repo" "$tag"
             fi
+            ;;
+        --files)
             shift
+            cmd_files "$@"
+            ;;
+        --dirs)
+            shift
+            cmd_dirs "$@"
+            ;;
+        --help|-h)
+            usage
             ;;
         *)
-            echo "Unknown option: $1"
-            echo "Usage:"
-            echo "  --docker <repo:tag>   Delete a specific Docker image"
-            echo "  --docker all          Delete all Docker images and associated data"
+            echo "Unknown subcommand: $1"
+            echo ""
+            usage
             exit 1
             ;;
-        esac
-    done
+    esac
 }
 
 main "$@"


### PR DESCRIPTION
## What changed
- add `--files` and `--dirs` subcommands to `parallel_works_scripts/cleanup_cluster.sh`
- add interactive confirmation before deletion runs
- add a pre-delete preview so the target files or directories can be reviewed first

## Why
- make the cleanup flow more targeted when operators only want file or directory cleanup
- reduce the chance of accidental deletion by showing what will be removed and requiring confirmation

## Impact
- users can run narrower cleanup operations from the existing script
- destructive cleanup actions now have an extra safety step before execution

## Validation
- reviewed the branch diff and commit history for `feat/cleanup-files-dirs-subcommands`
- branch pushed to `origin/feat/cleanup-files-dirs-subcommands`
