### PR TITLE
No longer creating ngen-bmi-forcing and ngen Singularity containers

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -134,8 +134,7 @@ Same as Test 3, but with nwm-fcst-mgr instead of nwm-cal-mgr.
    - ngen image tagged as: `feature-new-functionality`
 5. **Build arguments**:
    - ngen: `Building ngen (feature) Docker image with NGEN_FORCING_TAG=feature-forcing-update`
-6. **SIF files**: Should be named like:
-   - `ngen-feature-new-functionality-2024-01-15T10:30:00Z.sif`
+6. **No SIF files**: `ngen` and `ngen-bmi-forcing` are Docker-only — no `ngen-*.sif` or `ngen-bmi-forcing-*.sif` should be produced. The ngen binary and forcing engine are accessed via `nwm-cal-mgr.sif` at runtime.
 
 ### Verification Checklist
 - [ ] ngen-forcing auto-added to SELECTED_REPOS
@@ -143,7 +142,7 @@ Same as Test 3, but with nwm-fcst-mgr instead of nwm-cal-mgr.
 - [ ] NO default branch values in prompts
 - [ ] Branch name required (empty rejected)
 - [ ] Docker tags use actual branch names (sanitized)
-- [ ] SIF files use actual branch names
+- [ ] NO `ngen-*.sif` or `ngen-bmi-forcing-*.sif` created under `/ngencerf-app/singularity`
 - [ ] All images built locally (no pulling)
 - [ ] ngen uses ngen-forcing's branch-based tag
 

--- a/parallel_works_scripts/build_cluster.sh
+++ b/parallel_works_scripts/build_cluster.sh
@@ -150,9 +150,12 @@ images_for_repo() {
 }
 
 # function to determine if a repo has an associated SIF to build
+# ngen and ngen-bmi-forcing are built as Docker images only (consumed via FROM
+# by nwm-cal-mgr/nwm-fcst-mgr); at runtime the ngen binary and forcing engine
+# are accessed through nwm-cal-mgr.sif, so no standalone SIF is produced.
 repo_has_sif() {
     case "$1" in
-        ngencerf-server|ngencerf-ui|ngencerf-docker) return 1 ;;
+        ngencerf-server|ngencerf-ui|ngencerf-docker|ngen|ngen-bmi-forcing) return 1 ;;
         *) return 0 ;;
     esac
 }

--- a/parallel_works_scripts/build_cluster_REFERENCE.md
+++ b/parallel_works_scripts/build_cluster_REFERENCE.md
@@ -21,7 +21,7 @@ The script targets repos in `/ngencerf-app` and writes SIF files under `/ngencer
 - nwm-fcst-mgr
 - nwm-verf
 
-Only a subset produce SIFs (all except `ngencerf-*`).
+Only a subset produce SIFs (all except `ngencerf-*`, `ngen`, and `ngen-bmi-forcing`). Docker images are still built for `ngen` and `ngen-bmi-forcing` because `nwm-cal-mgr` and `nwm-fcst-mgr` consume them via `FROM`; at runtime the ngen binary and forcing engine are accessed through `nwm-cal-mgr.sif`.
 
 ## Inputs and CLI options
 - `--build-type=TYPE` with TYPE in `development`, `release`, `feature`.
@@ -39,7 +39,7 @@ Interactive mode is used if no args are passed and stdin is a TTY.
 ## Outputs
 - Docker images built or pulled from `ghcr.io/ngwpc`.
 - SIF files stored in `/ngencerf-app/singularity`.
-- A stable symlink per SIF base name (e.g., `ngen.sif`).
+- A stable symlink per SIF base name (e.g., `nwm-cal-mgr.sif`).
 - A log file at `/ngencerf-app/singularity/build_cluster_<timestamp>.log`.
 - A `.meta` file per SIF base name to track the last built image digest.
 
@@ -165,7 +165,7 @@ Interactive mode is used if no args are passed and stdin is a TTY.
 - `images_for_repo(repo)`
   - Maps repo names to Docker image and SIF base names.
 - `repo_has_sif(repo)`
-  - Excludes `ngencerf-*` repos from SIF generation.
+  - Excludes `ngencerf-*`, `ngen`, and `ngen-bmi-forcing` from SIF generation (Docker-only images).
 - `set_image_source_defaults()`
   - Applies default build/pull modes; forces build for feature builds.
 - `get_repo_branch(repo, build_type_default)`

--- a/parallel_works_scripts/extract_ngen_cli.sh
+++ b/parallel_works_scripts/extract_ngen_cli.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# overridable container path; fixed inner binary path (change if your image layout changes)
-NGEN_CONTAINER="${NGEN_CONTAINER:-/ngencerf-app/singularity/ngen.sif}"
+# overridable container path and ngen binary path inside container
+NGEN_CONTAINER="${NGEN_CONTAINER:-/ngencerf-app/singularity/nwm-cal-mgr.sif}"
 NGEN_BINARY="${NGEN_BINARY:-/ngen-app/ngen/cmake_build/ngen}"
 
 # test if singularity file and ngen binary are available

--- a/parallel_works_scripts/test_build_cluster.sh
+++ b/parallel_works_scripts/test_build_cluster.sh
@@ -33,9 +33,11 @@ TESTS_FAILED=0
 TEST_OUTPUT_DIR="/tmp/build_cluster_tests_$(date +%s)"
 mkdir -p "$TEST_OUTPUT_DIR"
 
-# Estimated test durations in seconds
-# Updated based on actual test runs
-TEST1_DURATION=3000  # 50 minutes - fresh dev build with dependencies (actual: 50 min)
+# Estimated test durations in seconds.
+# Note: ngen and ngen-bmi-forcing no longer produce SIFs (Docker-only), so these
+# estimates are higher than actual post-refactor runs. Recalibrate after the
+# next full test pass.
+TEST1_DURATION=3000  # 50 minutes - fresh dev build with dependencies
 TEST2_DURATION=2700  # 45 minutes - dev build, some cached layers but still rebuilds most
 TEST3_DURATION=3300  # 55 minutes - release build with --no-cache and tag checkouts
 TEST4_DURATION=3000  # 50 minutes - release build, similar to Test 3


### PR DESCRIPTION
Turns out, ngen-bmi-forcing.sif and ngen.sif are not needed. I moved some stuff to point to nwm-cal-mgr.sif which has everything the other two have. We no longer need to build these.