### PR TITLE
Add containerized ecFlow server build from source via Docker

### DIFF
--- a/nwm.v4.0.0/INSTALL.md
+++ b/nwm.v4.0.0/INSTALL.md
@@ -4,9 +4,9 @@
 
 # Clone `nwm-automation-scripts`
 
-Open a terminal and clone the `add_NCO_realtime_scripts` branch.
+Open a terminal and clone the `development` branch.
 
-  `git clone -b add_NCO_realtime_scripts  https://github.com/NGWPC/nwm-automation-scripts/tree/add_NCO_realtime_scripts`
+  `git clone -b development https://github.com/NGWPC/nwm-automation-scripts.git`
 
 # Install ecFlow Server
 

--- a/nwm.v4.0.0/INSTALL.md
+++ b/nwm.v4.0.0/INSTALL.md
@@ -8,13 +8,34 @@ Open a terminal and clone the `add_NCO_realtime_scripts` branch.
 
   `git clone -b add_NCO_realtime_scripts  https://github.com/NGWPC/nwm-automation-scripts/tree/add_NCO_realtime_scripts`
 
-# Run the installation script
+# Install ecFlow Server
+
+## (Docker) Container for ecFlow Server
+
+See notes in [ecflow-server/README.md](ecflow-server/README.md) for details.
+
+```bash
+# Build. Optionally run ecFlow server unit (choose yes or no).
+RUN_ECFLOW_SERVER_TESTS=no
+( cd ecflow-server && ./ecflow-server-docker-build.sh ${RUN_ECFLOW_SERVER_TESTS} )
+# Start.
+docker stop ecflow-server 2>/dev/null || true
+docker run --rm -d --name ecflow-server -p 3141:3141 -v "$(pwd)/ecflow-server/data/ecflow:/data/ecflow" ecflow-server /usr/local/ecflow/bin/ecflow_server
+# Ping.
+ecflow_client --ping
+```
+
+## Alternative ecFlow Server Installation
+
+TODO (e.g. apt install)
+
+# Run the testbed installation script
 
 ```
 cd nwm-automation-scripts/nwm.v4.0.0
 ./install_testbed.sh
 ```
-This will start a EcFlow server on the default port (3141) and install the EcFlow/NCO scripts for NWM.  The script also accept a port number as an argument. You can choose an unused port number if the default port number has already been used, 
+This will start a EcFlow server on the default port (3141) (unless it is already running) and install the EcFlow/NCO scripts for NWM.  The script also accept a port number as an argument. You can choose an unused port number if the default port number has already been used, 
 
 ```
 cd nwm-automation-scripts/nwm.v4.0.0

--- a/nwm.v4.0.0/ecflow-server/Dockerfile.ecflow-server
+++ b/nwm.v4.0.0/ecflow-server/Dockerfile.ecflow-server
@@ -1,0 +1,85 @@
+# ecflow server build.
+# 
+# With ecflow 5.13.8, boost 1.84 is the latest compatible version due to boost::asio::deadline_timer being removed in later boost versions.
+# This build is using ecflow 5.15.2, which is the first major release that included HTTPS API, and it supports later versions of boost.
+# 
+# Usage:
+#   Required build args: BOOST_VERS_DOT, BOOST_VERS_UNDER.
+#   e.g. `docker build --build-arg BOOST_VERS_DOT=1.91.0 --build-arg BOOST_VERS_UNDER=1_91_0 -f Dockerfile.ecflow-server .`
+# 
+#   Optional build args: BASE_IMAGE_NAME, BASE_IMAGE_TAG.
+#   It has been tested using base rockylinux:8 to match the current `ngen-forcing` and `ngen` build. `dnf` package manager usage is hard-coded. It might work on other OS that have `dnf`.
+#
+
+
+# Build args and base image
+ARG BASE_IMAGE_NAME=rockylinux
+ARG BASE_IMAGE_TAG=8
+
+FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
+
+# E.g. 1.91.0
+ARG BOOST_VERS_DOT
+# e.g. 1_91_0
+ARG BOOST_VERS_UNDER
+
+
+# Install deps
+## Python version 3.11 to match ngen-forcing and ngen
+## Boost 1.69 called out explicitly since ecflow 5.13.8 requires boost 1.69+,
+## and Rocky 8 comes with boost 1.66 by default.
+RUN dnf install epel-release -y
+# ecflow looks for static boost libs by default, so install boost169-static.
+# Might alternatively be able to use boost169-devel, with -DENABLE_STATIC_BOOST_LIBS=OFF
+# RUN dnf -y install git cmake gcc gcc-c++ boost169-static openssl-devel python3.11-devel
+RUN dnf -y install git cmake gcc gcc-c++ boost169-static openssl-devel python3.11-devel bzip2-devel zlib-devel libicu-devel
+
+
+# Build boost (from: https://www.boost.org/doc/user-guide/getting-started.html#from-source)
+RUN dnf -y install wget
+RUN wget https://archives.boost.io/release/${BOOST_VERS_DOT}/source/boost_${BOOST_VERS_UNDER}.tar.gz && \
+    tar xf boost_${BOOST_VERS_UNDER}.tar.gz && \
+    cd boost_${BOOST_VERS_UNDER} && \
+    ./bootstrap.sh --with-python=/usr/bin/python3.11 \
+    --prefix=/usr/local && \
+    ./b2 cxxflags=-fPIC && \
+    ./b2 install
+ENV BOOST_ROOT=/usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV CPLUS_INCLUDE_PATH=/usr/local/include:$CPLUS_INCLUDE_PATH
+
+
+# Build ecflow. From: https://ecflow.readthedocs.io/en/5.15.2/install/build_from_source.html
+## ~~2026-06-05: ecflow 5.13.8 calls for "ecbuild 3.4.0 or later", and ecbuild 3.14.2 is the latest version of ecbuild currently~~
+## 2026-06-05: ecflow 5.15.2 calls for "ecbuild 3.4.0 or later", and ecbuild 3.14.2 is the latest version of ecbuild currently
+RUN git clone --branch 5.15.2 https://github.com/ecmwf/ecflow.git /src/ecflow
+RUN git clone --branch 3.14.2 https://github.com/ecmwf/ecbuild.git /src/ecbuild
+## See docs for build options, e.g. custom compiler, Ninja, UI disabling, etc.
+## DENABLE_UI=OFF is needed here since we don't have Qt installed, not building the UI.
+WORKDIR /src/ecflow
+RUN cmake -B build -S . \
+    -DCMAKE_INSTALL_PREFIX=/usr/local/ecflow \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_SERVER=ON \
+    -DENABLE_UI=OFF \
+    -DENABLE_HTTP=ON \
+    -DENABLE_PYTHON=ON \
+    -DENABLE_TESTS=ON
+RUN cmake --build build -j 4
+WORKDIR /
+
+# TODO see if NCO has a preferred path for ECF_HOME or non-default port.
+ENV ECF_HOME=/data/ecflow
+ENV ECF_PORT=3141
+
+EXPOSE 3141
+RUN mkdir -p ${ECF_HOME}
+
+# Run ecflow tests, skipping the server authentication test.
+# RUN ctest --test-dir /src/ecflow/build -E "^u_server_authentication$"
+
+# Install ecflow
+RUN cmake --build /src/ecflow/build --target install
+ENV PATH="/usr/local/ecflow/bin:${PATH}"
+
+CMD ["ecflow_server", "--host=0.0.0.0"]

--- a/nwm.v4.0.0/ecflow-server/README.md
+++ b/nwm.v4.0.0/ecflow-server/README.md
@@ -17,7 +17,7 @@ See notes in `ecflow-server-docker-build.sh` and in `Dockerfile.ecflow-server` f
 cd nwm.v4.0.0/ecflow-server
 
 # Build the server image and run its `ctest` unit tests.
-# Note that the tests take significant time. Edit the bottom of the Dockerfile to omit running those.
+# Note that the tests take significant time. Edit the bottom of `ecflow-server-docker-build.sh` to omit running those.
 ./ecflow-server-docker-build.sh
 
 # (Optional) install ecFlow client on the host, and test the connection.

--- a/nwm.v4.0.0/ecflow-server/README.md
+++ b/nwm.v4.0.0/ecflow-server/README.md
@@ -9,7 +9,7 @@ Currently this includes build args to specify:
 1. Specific base image (currently must have `dnf` package manager, e.g. Rocky 8).
 2. The version of boost.
 
-See notes in `ecflow-server-docker-build.sh` and in `Dockerfile.ecflow-server` for details.
+See notes in [ecflow-server-docker-build.sh](ecflow-server-docker-build.sh) and in [Dockerfile.ecflow-server](Dockerfile.ecflow-server) for details.
 
 ## Steps
 
@@ -17,8 +17,8 @@ See notes in `ecflow-server-docker-build.sh` and in `Dockerfile.ecflow-server` f
 cd nwm.v4.0.0/ecflow-server
 
 # Build the server image and run its `ctest` unit tests.
-# Note that the tests take significant time. Edit the bottom of `ecflow-server-docker-build.sh` to omit running those.
-./ecflow-server-docker-build.sh
+# Note that the tests take significant time. Provide "yes" positional argument to run the tests.
+./ecflow-server-docker-build.sh "no"
 
 # (Optional) install ecFlow client on the host, and test the connection.
 # Assumes host uses `apt` and has ecflow-client package available (e.g. Ubuntu).

--- a/nwm.v4.0.0/ecflow-server/README.md
+++ b/nwm.v4.0.0/ecflow-server/README.md
@@ -1,0 +1,27 @@
+# Docker Build for ecFlow Server
+
+This is a Docker build for an ecFlow server.
+
+Currently this is hard-coded for ecFlow version 5.15.2.  See: https://ecflow.readthedocs.io/en/5.15.2/
+
+Currently this includes build args to specify:
+
+1. Specific base image (currently must have `dnf` package manager, e.g. Rocky 8).
+2. The version of boost.
+
+See notes in `ecflow-server-docker-build.sh` and in `Dockerfile.ecflow-server` for details.
+
+## Steps
+
+```bash
+cd nwm.v4.0.0/ecflow-server
+
+# Build the server image and run its `ctest` unit tests.
+# Note that the tests take significant time. Edit the bottom of the Dockerfile to omit running those.
+./ecflow-server-docker-build.sh
+
+# (Optional) install ecFlow client on the host, and test the connection.
+# Assumes host uses `apt` and has ecflow-client package available (e.g. Ubuntu).
+sudo apt update && sudo apt install -y ecflow-client
+./ecflow-server-test-from-local-client.sh
+```

--- a/nwm.v4.0.0/ecflow-server/ecflow-server-docker-build.sh
+++ b/nwm.v4.0.0/ecflow-server/ecflow-server-docker-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# 
+# Build a docker image of an ecflow server and run its built-in unit tests via `ctest`.
+# 
+
+set -euo pipefail
+
+# BOOST_VERS_DOT=1.89.0
+# BOOST_VERS_UNDER=1_89_0
+
+BOOST_VERS_DOT=1.91.0
+BOOST_VERS_UNDER=1_91_0
+
+echo "Building ecflow server image..."
+docker build \
+    --build-arg BOOST_VERS_DOT=${BOOST_VERS_DOT} \
+    --build-arg BOOST_VERS_UNDER=${BOOST_VERS_UNDER} \
+    -t ecflow-server \
+    -f Dockerfile.ecflow-server .
+echo "Done building ecflow server image."
+
+echo "Running ecflow server's unit tests..."
+docker run -t ecflow-server ctest --test-dir /src/ecflow/build -E '^u_server_authentication$'
+echo "Done with ecflow server tests."

--- a/nwm.v4.0.0/ecflow-server/ecflow-server-docker-build.sh
+++ b/nwm.v4.0.0/ecflow-server/ecflow-server-docker-build.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
-# 
-# Build a docker image of an ecflow server and run its built-in unit tests via `ctest`.
-# 
 
 set -euo pipefail
+
+## 
+## \brief 
+## Build a docker image of an ecflow server and optionally run its built-in unit tests via `ctest`.
+## 
+## \desc
+## Has 1 positional argument and 0 named arguments.
+## 
+## \option RUN_TESTS
+## Dictates whether ecFlow server unit tests are ran after building. Choices: [yes, no].
+## 
+
+
+RUN_TESTS=$1
 
 # BOOST_VERS_DOT=1.89.0
 # BOOST_VERS_UNDER=1_89_0
@@ -19,6 +30,10 @@ docker build \
     -f Dockerfile.ecflow-server .
 echo "Done building ecflow server image."
 
-echo "Running ecflow server's unit tests..."
-docker run -t ecflow-server ctest --test-dir /src/ecflow/build -E '^u_server_authentication$'
-echo "Done with ecflow server tests."
+if [ "${RUN_TESTS,,}" = "yes" ]; then
+    echo "Running ecflow server's unit tests..."
+    docker run -t ecflow-server ctest --test-dir /src/ecflow/build -E '^u_server_authentication$'
+    echo "Done with ecflow server tests."
+else
+    echo "Skipping ecflow server's unit tests."
+fi

--- a/nwm.v4.0.0/ecflow-server/ecflow-server-test-from-local-client.sh
+++ b/nwm.v4.0.0/ecflow-server/ecflow-server-test-from-local-client.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# 
+# Start a ecflow server container and test client connections to it.
+# 
+
+set -euo pipefail
+
+NETWORK="ecflow-net"
+
+# idempotent network creation
+echo "Creating network..."
+docker network inspect "${NETWORK}" >/dev/null 2>&1 || docker network create "${NETWORK}"
+
+echo "Stopping container if it already exists..."
+docker stop ecflow-server 2>/dev/null || true
+
+# Start server container
+echo "Starting server container..."
+docker run --rm -d --net "${NETWORK}" --name ecflow-server -p 3141:3141 -v "$(pwd)/data/ecflow:/data/ecflow" ecflow-server /usr/local/ecflow/bin/ecflow_server
+echo "Container started."
+
+echo "Pinging server container from another container..."
+docker run --rm --net "${NETWORK}" --name ecflow-client ecflow-server ecflow_client --host=ecflow-server --ping
+echo "Successful ping to server from another container."
+
+echo "Ping from local client..."
+ecflow_client --host=localhost --port 3141 --ping
+echo "Succeeded ping from local client."
+
+echo "Stopping server container..."
+docker stop ecflow-server 2>/dev/null || true
+echo "Stopped server container."
+
+set -x
+exit 0


### PR DESCRIPTION
Add containerized ecFlow server build from source via Docker.

Includes a new `REAMDE.md` for building the Docker container, for installing a ecFlow client on the host, and for pinging the containerized server from the host client.