### PR TITLE
Transition from default to regionalization ngen runs

### DIFF
--- a/nwm.v4.0.0/scripts/exnwm.sh
+++ b/nwm.v4.0.0/scripts/exnwm.sh
@@ -98,7 +98,15 @@ if [[ "${CASETYPE}" == *"_VPU" ]]; then
   export VPU=$(ecflow_client --query variable ${ECF_NAME}:VPU)
   RUN_CASETYPE="${CASETYPE}_${VPU}"
   VPU_ARG="--vpu ${VPU}"
+  REGION_SUBDIR="vpu_${VPU}"
+else
+  REGION_SUBDIR="01123000"
 fi
+
+# Set paths to static regionalization input files
+REGION_DATA_ROOT="${HOME}/rte-test-data/regionalization/${REGION_SUBDIR}"
+FORM_ASSIGN_FILE="${REGION_DATA_ROOT}/formulation_assignment.csv"
+CAT_GRP_FILE="${REGION_DATA_ROOT}/catchment_groups.csv"
 
 # configure and run RTE
 if [[ ${CASETYPE} == "CONUS_ANALYSIS_ASSIM" ||  ${CASETYPE} == "CONUS_ANALYSIS_ASSIM_VPU" ]]; then
@@ -110,6 +118,8 @@ if [[ ${CASETYPE} == "CONUS_ANALYSIS_ASSIM" ||  ${CASETYPE} == "CONUS_ANALYSIS_A
     --working-dir ${DATA}                                \
     --comout ${COMOUT}                                   \
     --previous-day-comout ${COMOUTm1}                    \
+    --form-assign-file "${FORM_ASSIGN_FILE}"             \
+    --cat-grp-file "${CAT_GRP_FILE}"                     \
     ${VPU_ARG}
 elif [[ ${CASETYPE} == "CONUS_SHORT_RANGE" || ${CASETYPE} == "CONUS_SHORT_RANGE_VPU" ]]; then
   python3.12  ${USHnwm}/nwm-realtime/nwm_realtime_fcst.py    \
@@ -120,6 +130,8 @@ elif [[ ${CASETYPE} == "CONUS_SHORT_RANGE" || ${CASETYPE} == "CONUS_SHORT_RANGE_
     --working-dir ${DATA}                                \
     --comout ${COMOUT}                                   \
     --previous-day-comout ${COMOUTm1}                    \
+    --form-assign-file "${FORM_ASSIGN_FILE}"             \
+    --cat-grp-file "${CAT_GRP_FILE}"                     \
     ${VPU_ARG}
 elif [[ ${CASETYPE} == "CONUS_EXT_ANALYSIS_ASSIM" || ${CASETYPE} == "CONUS_EXT_ANALYSIS_ASSIM_VPU" ]]; then
   export cyc=16
@@ -131,6 +143,8 @@ elif [[ ${CASETYPE} == "CONUS_EXT_ANALYSIS_ASSIM" || ${CASETYPE} == "CONUS_EXT_A
     --working-dir ${DATA}                                \
     --comout ${COMOUT}                                   \
     --previous-day-comout ${COMOUTm1}                    \
+    --form-assign-file "${FORM_ASSIGN_FILE}"             \
+    --cat-grp-file "${CAT_GRP_FILE}"                     \
     ${VPU_ARG}
 fi
 
@@ -152,7 +166,7 @@ if [ ! -d ${COMOUT}/logs/${cyc}/${RUN_CASETYPE} ]; then
 fi
 
 #NGen logs
-cp ${DATA}/default/test_bmi/*/*.log ${COMOUT}/logs/${cyc}/${RUN_CASETYPE}/
+cp ${DATA}/regionalization/test_bmi/*/*.log ${COMOUT}/logs/${cyc}/${RUN_CASETYPE}/
 
 #log messages from MSWM
 cp -r ${DATA}/logs/* ${COMOUT}/logs/${cyc}/${RUN_CASETYPE}/
@@ -171,15 +185,15 @@ if [[ ${CASETYPE} == "CONUS_ANALYSIS_ASSIM" || ${CASETYPE} == "CONUS_EXT_ANALYSI
   fi
 
   #copy warm states
-  cp -r ${DATA}/default/test_bmi/*/state_save_${PDY}${cyc} ${COMOUT}/${cyc}/${RUN_CASETYPE}/
-  cp -r ${DATA}/default/test_bmi/*/state_save_$($NDATE ${run1_offset} ${PDY}${cyc}) ${COMOUT}/${cyc}/${RUN_CASETYPE}/
+  cp -r ${DATA}/regionalization/test_bmi/*/state_save_${PDY}${cyc} ${COMOUT}/${cyc}/${RUN_CASETYPE}/
+  cp -r ${DATA}/regionalization/test_bmi/*/state_save_$($NDATE ${run1_offset} ${PDY}${cyc}) ${COMOUT}/${cyc}/${RUN_CASETYPE}/
 
   #cat-*.csv and nex-*.csv files
-  cp -r ${DATA}/default/test_bmi/*/Output_${PDY}${cyc} ${COMOUT}/${cyc}/${RUN_CASETYPE}/
-  cp -r ${DATA}/default/test_bmi/*/Output_$($NDATE ${run1_offset} ${PDY}${cyc}) ${COMOUT}/${cyc}/${RUN_CASETYPE}/
+  cp -r ${DATA}/regionalization/test_bmi/*/Output_${PDY}${cyc} ${COMOUT}/${cyc}/${RUN_CASETYPE}/
+  cp -r ${DATA}/regionalization/test_bmi/*/Output_$($NDATE ${run1_offset} ${PDY}${cyc}) ${COMOUT}/${cyc}/${RUN_CASETYPE}/
 else
   #catchment and T-route output files
-  cp ${DATA}/default/test_bmi/*/Output/*.nc ${COMOUT}/${cyc}/${RUN_CASETYPE}/
+  cp ${DATA}/regionalization/test_bmi/*/Output/*.nc ${COMOUT}/${cyc}/${RUN_CASETYPE}/
 fi 
 export err=$?; err_chk
 

--- a/nwm.v4.0.0/scripts/exnwm.sh
+++ b/nwm.v4.0.0/scripts/exnwm.sh
@@ -104,7 +104,7 @@ else
 fi
 
 # Set paths to static regionalization input files
-REGION_DATA_ROOT="${HOME}/rte-test-data/regionalization/${REGION_SUBDIR}"
+REGION_DATA_ROOT="${HOMEnwm}/ush/nwm-msw-mgr/src/mswm/example_inputs/regionalization/${REGION_SUBDIR}"
 FORM_ASSIGN_FILE="${REGION_DATA_ROOT}/formulation_assignment.csv"
 CAT_GRP_FILE="${REGION_DATA_ROOT}/catchment_groups.csv"
 

--- a/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
+++ b/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
@@ -529,12 +529,12 @@ def main():
         help="Path to the local hydrofabric geopackage file"
     )
     parser.add_argument(
-        "--form_assign_file",
+        "--form-assign-file",
         required=True,
         help="Path to the regionalization formulation assignment file"
     )
     parser.add_argument(
-        "--cat_grp_file",
+        "--cat-grp-file",
         default=None,
         help="Path to the regionalization catchment grouping file"
     )

--- a/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
+++ b/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
@@ -64,12 +64,18 @@ class NWMRealtimeFcst:
     def __init__(self, config_name: str, domain: str, t0: datetime,
                  package_dir: str, working_dir: str, comout: str,
                  previous_day_comout: str, vpu: str | None = None,
-                 hydrofab_file: str | None = None):
+                 hydrofab_file: str | None = None,
+                 form_assign_file: str | None = None,
+                 cat_grp_file: str | None = None):
         if config_name not in self._FORECAST_LENGTHS:
             raise ValueError(f"Unknown config_name: {config_name}")
         if domain not in (self.DOMAIN_CONUS, self.DOMAIN_HAWAII,
                           self.DOMAIN_ALASKA, self.DOMAIN_PUERTO_RICO):
             raise ValueError(f"Unknown domain: {domain}")
+        if form_assign_file is None:
+            raise ValueError("form_assign_file is required for regionalization runs.")
+        if cat_grp_file is None:
+            raise ValueError("cat_grp_file is required for regionalization runs.")
 
         self.config_name = config_name
         self.domain = domain
@@ -81,6 +87,8 @@ class NWMRealtimeFcst:
         self.forecast_length = self._FORECAST_LENGTHS[config_name]
         self.vpu = vpu
         self.hydrofab_file = hydrofab_file
+        self.form_assign_file = form_assign_file
+        self.cat_grp_file = cat_grp_file
         self.gageid = "01123000"
     # ------------------------------------------------------------------ #
     # Derived paths (mirrors $USHnwm and $PARMnwm from the ex-script)
@@ -105,6 +113,12 @@ class NWMRealtimeFcst:
     @property
     def output_format_arg(self) -> str:
         return ' --output_format NetCDF'
+    def form_assign_arg(self) -> str:
+        return f' -faf "{self.form_assign_file}"'
+
+    @property
+    def cat_grp_arg(self) -> str:
+        return f' -cgf "{self.cat_grp_file}"'
 
     # ------------------------------------------------------------------ #
     # Forecast window helpers
@@ -219,8 +233,8 @@ class NWMRealtimeFcst:
         os.makedirs(f"{self.working_dir}/logs/rte", exist_ok=True)
         os.makedirs(f"{self.working_dir}/logs/docker", exist_ok=True)
         os.makedirs(f"{self.working_dir}/logs/ngen", exist_ok=True)
-        os.makedirs(f"{self.working_dir}/default/test_bmi/{self.run_id}/logs", exist_ok=True)
-        touch_file_if_not_exists(f"{self.working_dir}/default/test_bmi/{self.run_id}/logs/msw_mgr_default.log")
+        os.makedirs(f"{self.working_dir}/regionalization/test_bmi/{self.run_id}/logs", exist_ok=True)
+        touch_file_if_not_exists(f"{self.working_dir}/regionalization/test_bmi/{self.run_id}/logs/msw_mgr_regionalization.log")
 
         config_bashrc = os.path.join(self.working_dir, "config.bashrc")
         with open(config_bashrc) as f:
@@ -258,7 +272,7 @@ class NWMRealtimeFcst:
         }
 
         case_type = self._CASE_TYPES.get((self.config_name, self.domain))
-        dst_state_save = os.path.join(self.working_dir, "default", "test_bmi", self.run_id, "state_save")
+        dst_state_save = os.path.join(self.working_dir, "regionalization", "test_bmi", self.run_id, "state_save")
         src_state_save = state_save_src_fns[case_type]()
         if os.path.isdir(src_state_save):
             shutil.copytree(src_state_save, dst_state_save, dirs_exist_ok=True)
@@ -277,7 +291,7 @@ class NWMRealtimeFcst:
 
     def _docker_run(self, docker_args: str) -> int:
         """Run a single RTE invocation inside the container; return its exit code."""
-        cmd = f'source run.sh && docker_run python -um "ngen_rte.run_default" {docker_args}'
+        cmd = f'source run.sh && docker_run python -um "ngen_rte.run_regionalization_standalone" {docker_args}'
         result = subprocess.run(["bash", "-c", cmd], cwd=self.working_dir)
         return result.returncode
 
@@ -319,10 +333,10 @@ class NWMRealtimeFcst:
         failing run, or of run 2 if both ran."""
         l1, l2 = window_hours
         # Host run directory; working_dir is mounted at /ngwpc/run_ngen in the container.
-        run_dir = os.path.join(self.working_dir, "default", "test_bmi", self.run_id)
+        run_dir = os.path.join(self.working_dir, "regionalization", "test_bmi", self.run_id)
         # Hardcoded container path where RTE writes/reads the saved model state
         # (the run directory inside the /ngwpc/run_ngen mount).
-        state_save_dir = f"/ngwpc/run_ngen/default/test_bmi/{self.run_id}/state_save"
+        state_save_dir = f"/ngwpc/run_ngen/regionalization/test_bmi/{self.run_id}/state_save"
 
         # Run 1 initial states: load previous-cycle warm states if present, else cold start.
         if os.path.isdir(src_state_save):
@@ -345,7 +359,7 @@ class NWMRealtimeFcst:
         checkpoint_arg = f" --checkpoint_interval {run1_checkpoint_interval}" if run1_checkpoint_interval is not None else ""
         docker_args = (
             f'-n 2 -fconfig "{fconfig}" -dt "{dt1}" --lookback {self._lookback_minutes(l1)} '
-            f'--save_state -rname "{rname}"{extra_args}{load_state_arg}{checkpoint_arg}{self.vpu_arg}{self.hydrofab_arg}'
+            f'--save_state -rname "{rname}"{extra_args}{load_state_arg}{checkpoint_arg}{self.vpu_arg}{self.hydrofab_arg}{self.form_assign_arg}{self.cat_grp_arg}'
             f'{self.output_format_arg}'
         )
         rc = self._docker_run(docker_args)
@@ -376,7 +390,7 @@ class NWMRealtimeFcst:
         dt2 = self.t0.strftime("%Y-%m-%d %H:%M:%S")
         docker_args = (
             f'-n 2 -fconfig "{fconfig}" -dt "{dt2}" --lookback {self._lookback_minutes(l2)} '
-            f'--save_state -rname "{rname}"{extra_args} --load_state_from "{state_save_dir}"{self.vpu_arg}{self.hydrofab_arg}'
+            f'--save_state -rname "{rname}"{extra_args} --load_state_from "{state_save_dir}"{self.vpu_arg}{self.hydrofab_arg}{self.form_assign_arg}{self.cat_grp_arg}'
             f'{self.output_format_arg}'
         )
         rc = self._docker_run(docker_args)
@@ -404,7 +418,7 @@ class NWMRealtimeFcst:
             return self._run_two_pass_ana(
                 case_type=case_type,
                 fconfig="standard_ana",
-                rname="default_ana",
+                rname="region_ana",
                 src_state_save=self._ana_state_save_src(),
                 window_hours=(1, 2),
                 extra_args=" -nwmout",
@@ -414,7 +428,7 @@ class NWMRealtimeFcst:
             return self._run_two_pass_ana(
                 case_type=case_type,
                 fconfig="extended_ana",
-                rname="default_extended_ana",
+                rname="region_extended_ana",
                 src_state_save=self._ext_ana_state_save_src(),
                 window_hours=(24, 4),
                 extra_args=" -nwmout",
@@ -425,7 +439,7 @@ class NWMRealtimeFcst:
             src_state_save = self._short_range_state_save_src()
             # Hardcoded container path where RTE writes/reads the saved model state
             # (the run directory inside the /ngwpc/run_ngen mount).
-            state_save_dir = f"/ngwpc/run_ngen/default/test_bmi/{self.run_id}/state_save"
+            state_save_dir = f"/ngwpc/run_ngen/regionalization/test_bmi/{self.run_id}/state_save"
             if os.path.isdir(src_state_save):
                 print(
                     f"INFO: Warm states found at {src_state_save}; "
@@ -442,7 +456,8 @@ class NWMRealtimeFcst:
                 load_state_arg = ""
             docker_args = (
                 f'-n 2 -fconfig "short_range" -dt "{rte_start_time}" -rname "default_short" -nwmout'
-                f'{load_state_arg}{self.vpu_arg}{self.hydrofab_arg}{self.output_format_arg} --checkpoint_interval 1'
+                f'{load_state_arg}{self.vpu_arg}{self.hydrofab_arg}{self.form_assign_arg}{self.cat_grp_arg}{self.output_format_arg} --checkpoint_interval 1'
+                f'{self.output_format_arg}'
             )
             return self._docker_run(docker_args)
 
@@ -513,6 +528,16 @@ def main():
         default=None,
         help="Path to the local hydrofabric geopackage file"
     )
+    parser.add_argument(
+        "--form_assign_file",
+        required=True,
+        help="Path to the regionalization formulation assignment file"
+    )
+    parser.add_argument(
+        "--cat_grp_file",
+        default=None,
+        help="Path to the regionalization catchment grouping file"
+    )
     args = parser.parse_args()
     t0 = datetime.strptime(args.t0, "%Y-%m-%d %H:%M:%S")
     package_dir = args.package_dir
@@ -529,6 +554,8 @@ def main():
         previous_day_comout=args.previous_day_comout,
         vpu=args.vpu,
         hydrofab_file=args.hydrofab_file,
+        form_assign_file=args.form_assign_file,
+        cat_grp_file=args.cat_grp_file,
     )
 
     print(f"Config   : {fcst.config_name}")

--- a/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
+++ b/nwm.v4.0.0/ush/nwm-realtime/nwm_realtime_fcst.py
@@ -113,6 +113,8 @@ class NWMRealtimeFcst:
     @property
     def output_format_arg(self) -> str:
         return ' --output_format NetCDF'
+
+    @property
     def form_assign_arg(self) -> str:
         return f' -faf "{self.form_assign_file}"'
 


### PR DESCRIPTION
This PR updates nwm-automation-scripts to run regionalization realizations instead of default realizations, using the newly implemented `ngen_rte.run_regionalization_standalone`. Changes include:

- Switches RTE module from `run_default` to `run_regionalization_standalone`
- Adds `--form-assign-file` and `--cat-grp-file` args to `nwm_realtime_fcst.py`, which point to regionalization inputs. For example gage 01123000 and vpu 03s, these are derived from the installed msw-mgr packge in `example_inputs/regionalziation/{region_subdir}/` directory
- Adds `--output_format NetCDF` to all docker run commands
- Updates working directory structure from `default/test_bmi/` to `regionalization/test_bmi`
- `exnwm.sh` derives `FORM_ASSIGN_FILE` and `CAT_GRP_FILE` from the relative location of the msw-mgr package installation

Additional confirmation from Zhengtao may be required to ensure that the regionalization input file paths are properly set in the ECFlow instance.